### PR TITLE
Require explicit officer selection for internal affairs

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -100,6 +100,15 @@ ENERGY_COST_ADMIN = 8   # farm, trade, research
 ENERGY_COST_MILITARY = 10  # train, fortify, recruit
 ENERGY_RECOVERY = 12  # For idle officers
 
+# Internal affairs costs
+INTERNAL_ACTION_GOLD_COSTS = {
+    "farm": 50,
+    "flood": 50,
+    "trade": 75,
+    "research": 90,
+}
+INTERNAL_ACTION_ENERGY_COST = 20
+
 # =================== Economy ===================
 TROOP_UPKEEP_RATE = 0.12  # Food consumption per troop
 DESERTION_MIN_RATE = 0.05

--- a/src/models.py
+++ b/src/models.py
@@ -44,6 +44,7 @@ class Officer:
     task: Optional[str] = None
     task_city: Optional[str] = None
     busy: bool = False
+    assignment_energy_spent: bool = False
 
 
 @dataclass

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -140,29 +140,29 @@ class TestTransferCity:
 class TestAssignmentEffect:
     """Tests for officer assignment effects."""
     
-    def test_farm_increases_food(self, populated_game_state):
-        """Farming task should increase city food."""
+    def test_farm_increases_agriculture(self, populated_game_state):
+        """Farming task should increase city agriculture development."""
         officer = populated_game_state.officers["TestOfficer"]
         city = populated_game_state.cities["TestCity"]
         officer.task = "farm"
         officer.task_city = city.name
-        
-        initial_food = city.food
+
+        initial_agri = city.agri
         engine.assignment_effect(populated_game_state, officer, city)
-        
-        assert city.food > initial_food
-    
-    def test_trade_increases_gold(self, populated_game_state):
-        """Trading task should increase city gold."""
+
+        assert city.agri > initial_agri
+
+    def test_trade_increases_commerce(self, populated_game_state):
+        """Trading task should increase city commerce development."""
         officer = populated_game_state.officers["TestOfficer"]
         city = populated_game_state.cities["TestCity"]
         officer.task = "trade"
         officer.task_city = city.name
-        
-        initial_gold = city.gold
+
+        initial_commerce = city.commerce
         engine.assignment_effect(populated_game_state, officer, city)
-        
-        assert city.gold > initial_gold
+
+        assert city.commerce > initial_commerce
     
     def test_research_increases_tech(self, populated_game_state):
         """Research task should increase city tech."""
@@ -326,7 +326,7 @@ class TestMonthlyEconomy:
         engine.monthly_economy(populated_game_state)
         
         assert city.troops < 100  # Some troops deserted
-        assert city.gold == 0  # Gold reset to 0
+        assert city.gold >= 0  # Gold should not remain negative
     
     def test_january_tax_bonus(self, populated_game_state):
         """January should provide tax bonus."""

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -171,18 +171,18 @@ class TestOfficerAssignmentWorkflow:
         officer.location = "Xuchang"
         officer.task = "farm"
         officer.energy = 100
-        officer.pol = 80  # High politics for farming
-        
+        officer.pol = 80  # Legacy attribute retained for compatibility
+
         city = gs.cities["Xuchang"]
         city.owner = gs.player_faction
-        
-        initial_food = city.food
-        
+
+        initial_agri = city.agri
+
         # Process assignment (note: signature is assignment_effect(gs, off, city))
         engine.assignment_effect(gs, officer, city)
-        
-        # Food should have increased
-        assert city.food > initial_food
+
+        # Agriculture development should have increased
+        assert city.agri > initial_agri
         
         # Officer energy should have decreased
         assert officer.energy < 100


### PR DESCRIPTION
## Summary
- add a manual officer selection flow for internal affairs assignments, including gold costs and end-of-month execution
- update assignment processing to grow development stats and scale monthly economy income with city development
- extend officer state and tests to cover the new workflow and long-running assignments

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f6dd5181dc832389b8c111dc497c80